### PR TITLE
ci: manually trigger builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,7 @@
 name: Build zip
 
 on:
-    push:
-        branches: [master]
+    workflow_dispatch:
 
 jobs:
     build:


### PR DESCRIPTION
Instead of using commits to master as trigger for build, lets use the Github Action's manual workflow trigger.